### PR TITLE
Allow request body with another encoding

### DIFF
--- a/src/Mockaco/Extensions/HttpRequestExtensions.cs
+++ b/src/Mockaco/Extensions/HttpRequestExtensions.cs
@@ -104,7 +104,8 @@ namespace Microsoft.AspNetCore.Http
         {
             httpRequest.EnableBuffering();
 
-            var reader = new StreamReader(httpRequest.Body);
+            var encoding = GetEncodingFromContentType(httpRequest.ContentType) ?? Encoding.UTF8;
+            var reader = new StreamReader(httpRequest.Body, encoding); 
 
             var body = await reader.ReadToEndAsync();
 
@@ -126,6 +127,15 @@ namespace Microsoft.AspNetCore.Http
             }
 
             return acceptLanguages?.Select(l => l.Value.ToString());
+        }
+
+        private static Encoding GetEncodingFromContentType(string contentType)
+        {
+            // although the value is well parsed, the encoding is null when it is not informed
+            if (MediaTypeHeaderValue.TryParse(contentType, out var parsedValue))
+                return parsedValue.Encoding;
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fix an issue when you try to read a request body which it is not using UTF-8 encoding. Now it gets encoding from request ContentType or it uses UTF-8 as a default.