### PR TITLE
Add support for query string parameters for route matching

### DIFF
--- a/src/Mockaco/Common/RouteMatcher.cs
+++ b/src/Mockaco/Common/RouteMatcher.cs
@@ -1,29 +1,45 @@
-﻿using Microsoft.AspNetCore.Routing;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace Mockaco
 {
     public class RouteMatcher
     {
-        public RouteValueDictionary Match(string routeTemplate, string requestPath)
+        public RouteValueDictionary Match(string routeTemplate, string requestPath, IQueryCollection query)
         {
-            if(string.IsNullOrWhiteSpace(routeTemplate))
+            var regex = new Regex(@"(.*)(\?[^{}]*$)");
+            var match = regex.Match(routeTemplate);
+
+            if (match.Success)
             {
-                return null;
+                var queryString = match.Groups[2].Value;
+                routeTemplate = match.Groups[1].Value;
+
+                var queryInTemplate = QueryHelpers.ParseQuery(queryString);
+
+                foreach (var (key, value) in query)
+                {
+                    if (!queryInTemplate.ContainsKey(key.TrimStart('?')) || queryInTemplate[key.TrimStart('?')] != value)
+                    {
+                        return null;
+                    }
+                }
             }
 
             var template = TemplateParser.Parse(routeTemplate);
-
             var matcher = new TemplateMatcher(template, GetDefaults(template));
-
             var values = new RouteValueDictionary();
 
             return matcher.TryMatch(requestPath, values) ? values : null;
         }
 
-        public bool IsMatch(string routeTemplate, string requestPath)
+        public bool IsMatch(string routeTemplate, string requestPath, IQueryCollection query)
         {
-            return Match(routeTemplate, requestPath) != null;
+            return Match(routeTemplate, requestPath, query) != null;
         }
 
         private RouteValueDictionary GetDefaults(RouteTemplate parsedTemplate)

--- a/src/Mockaco/Extensions/HttpRequestExtensions.cs
+++ b/src/Mockaco/Extensions/HttpRequestExtensions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Http
         {
             var routeMatcher = new RouteMatcher();
 
-            return routeMatcher.Match(mock.Route, request.Path);
+            return routeMatcher.Match(mock.Route, request.Path, request.Query);
         }
 
         public static bool HasXmlContentType(this HttpRequest request)

--- a/src/Mockaco/Templating/Request/RequestRouteMatcher.cs
+++ b/src/Mockaco/Templating/Request/RequestRouteMatcher.cs
@@ -11,12 +11,9 @@ namespace Mockaco
         {
             var routeMatcher = new RouteMatcher();
 
-            if (string.IsNullOrWhiteSpace(mock?.Route))
-            {
-                return Task.FromResult(routeMatcher.IsMatch(DefaultRoute, httpRequest.Path));
-            }
-
-            return Task.FromResult(routeMatcher.IsMatch(mock.Route, httpRequest.Path));
+            return Task.FromResult(string.IsNullOrWhiteSpace(mock?.Route) ? 
+                routeMatcher.IsMatch(DefaultRoute, httpRequest.Path, httpRequest.Query) : 
+                routeMatcher.IsMatch(mock.Route, httpRequest.Path, httpRequest.Query));
         }
     }
 }


### PR DESCRIPTION
My use case for mockaco, at the moment, is to mock soap gateway, which uses controller.asmx?method style of url. 
Before, it was blowing anytime it encounters a '?' in template url.

This small modification to the code allows for matching urls with query strings.

New behaviour
Template = "/path?q=v"

Url = /path
MATCH

Url = /path?q=v
MATCH

Url = /path?q2=v
FAIL

Url = /path?q=v2
FAIL

Haven't tried with multiple query parameters, but it should work like described. Also, haven't covered an edge case where query parameters duplicate, although QueryCollection should handle such a case.

Hope that helps and thank you for creating this very cool project.