### PR TITLE
add http API interface

### DIFF
--- a/src/Mockaco.AspNetCore/AdminApi/AdminApiExtensions.cs
+++ b/src/Mockaco.AspNetCore/AdminApi/AdminApiExtensions.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mockaco.AdminApi
+{
+    internal class AdminApiExtensions
+    {
+
+        internal static IResult Handler([FromQuery] string token,
+                                       [FromRoute] string action,
+                                       [FromBody] AdminApiRequest model,
+                                       [FromServices] IOptionsSnapshot<MockacoOptions> options,
+                                       [FromServices] ITemplateProvider templateProvider)
+        {
+            var _action = action?.ToLower();
+
+            var result = new AdminApiResult()
+            {
+                Status = true
+            };
+
+            try
+            {
+                if (token == null || !token.Equals(options.Value.AdminApiSecretKey))
+                {
+                    throw new Exception("Invalid secret key");
+                }
+
+                switch (_action)
+                {
+                    case "list":
+                        result.Data = templateProvider.GetTemplates();
+                        break;
+                    case "remove":
+                        templateProvider.Remove(model.Name);
+                        break;
+                    case "update":
+                        templateProvider.Update(model.Name, model.Content);
+                        break;
+                    default:
+                        throw new NotSupportedException($"action {_action} is not supported.");
+                }
+            }
+            catch (Exception ex)
+            {
+                result = new AdminApiResult()
+                {
+                    Status = false,
+                    Message = ex.Message,
+                };
+            }
+
+
+            return Results.Ok(result);
+        }
+
+    }
+}

--- a/src/Mockaco.AspNetCore/AdminApi/AdminApiRequest.cs
+++ b/src/Mockaco.AspNetCore/AdminApi/AdminApiRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Mockaco.AdminApi
+{
+    public class AdminApiRequest
+    {
+        public string Name { get; set; }
+        public string Content { get; set; }
+    }
+}

--- a/src/Mockaco.AspNetCore/AdminApi/AdminApiResult.cs
+++ b/src/Mockaco.AspNetCore/AdminApi/AdminApiResult.cs
@@ -1,0 +1,9 @@
+﻿namespace Mockaco.AdminApi
+{
+    public class AdminApiResult
+    {
+        public bool Status { get; set; }
+        public string Message { get; set; }
+        public object Data { get; set; }
+    }
+}

--- a/src/Mockaco.AspNetCore/DependencyInjection/MockacoApplicationBuilder.cs
+++ b/src/Mockaco.AspNetCore/DependencyInjection/MockacoApplicationBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Mockaco;
+using Mockaco.AdminApi;
 using Mockaco.Verifyer;
 
 namespace Microsoft.AspNetCore.Builder
@@ -12,6 +13,8 @@ namespace Microsoft.AspNetCore.Builder
             app.UseRouting();
             var options = app.ApplicationServices.GetRequiredService<IOptions<MockacoOptions>>().Value;
             app.UseEndpoints(endpoints => endpoints.Map($"/{options.VerificationEndpointPrefix}/{options.VerificationEndpointName}", VerifyerExtensions.Verify));
+
+            app.UseEndpoints(endpoints => endpoints.Map($"/{options.AdminApiEndpointPrefix}/{options.AdminApiEndpointName}/{{action}}", AdminApiExtensions.Handler));
 
             app.UseMiddleware<ErrorHandlingMiddleware>();
             configure(app);

--- a/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
+++ b/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
@@ -6,7 +6,7 @@ namespace Mockaco
     {
         public HttpStatusCode DefaultHttpStatusCode { get; set; }
 
-        public HttpStatusCode ErrorHttpStatusCode { get; set; }       
+        public HttpStatusCode ErrorHttpStatusCode { get; set; }
 
         public string DefaultHttpContentType { get; set; }
 
@@ -19,6 +19,12 @@ namespace Mockaco
         public string VerificationEndpointPrefix { get; set; }
 
         public string VerificationEndpointName { get; set; }
+
+        public string AdminApiEndpointPrefix { get; set; }
+
+        public string AdminApiEndpointName { get; set; }
+        public string AdminApiSecretKey { get; set; }
+
 
         public TemplateFileProviderOptions TemplateFileProvider { get; set; }
 
@@ -33,6 +39,8 @@ namespace Mockaco
             VerificationEndpointPrefix = "_mockaco";
             VerificationEndpointName = "verification";
             TemplateFileProvider = new();
+            AdminApiEndpointPrefix = "_mockaco";
+            AdminApiEndpointName = "api";
         }
     }
 }

--- a/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,6 +1,20 @@
 ﻿Bogus.PhoneNumberExtensions
 Microsoft.AspNetCore.Builder.MockacoApplicationBuilder
 Microsoft.Extensions.DependencyInjection.MockacoServiceCollection
+Mockaco.AdminApi.AdminApiRequest
+Mockaco.AdminApi.AdminApiRequest.AdminApiRequest() -> void
+Mockaco.AdminApi.AdminApiRequest.Content.get -> string
+Mockaco.AdminApi.AdminApiRequest.Content.set -> void
+Mockaco.AdminApi.AdminApiRequest.Name.get -> string
+Mockaco.AdminApi.AdminApiRequest.Name.set -> void
+Mockaco.AdminApi.AdminApiResult
+Mockaco.AdminApi.AdminApiResult.AdminApiResult() -> void
+Mockaco.AdminApi.AdminApiResult.Data.get -> object
+Mockaco.AdminApi.AdminApiResult.Data.set -> void
+Mockaco.AdminApi.AdminApiResult.Message.get -> string
+Mockaco.AdminApi.AdminApiResult.Message.set -> void
+Mockaco.AdminApi.AdminApiResult.Status.get -> bool
+Mockaco.AdminApi.AdminApiResult.Status.set -> void
 Mockaco.IFakerFactory
 Mockaco.IFakerFactory.GetDefaultFaker() -> Bogus.Faker
 Mockaco.IFakerFactory.GetFaker(System.Collections.Generic.IEnumerable<string> acceptLanguages) -> Bogus.Faker
@@ -37,6 +51,12 @@ Mockaco.Mock.RawTemplate.set -> void
 Mockaco.Mock.Route.get -> string
 Mockaco.Mock.Route.set -> void
 Mockaco.MockacoOptions
+Mockaco.MockacoOptions.AdminApiEndpointName.get -> string
+Mockaco.MockacoOptions.AdminApiEndpointName.set -> void
+Mockaco.MockacoOptions.AdminApiEndpointPrefix.get -> string
+Mockaco.MockacoOptions.AdminApiEndpointPrefix.set -> void
+Mockaco.MockacoOptions.AdminApiSecretKey.get -> string
+Mockaco.MockacoOptions.AdminApiSecretKey.set -> void
 Mockaco.MockacoOptions.DefaultHttpContentType.get -> string
 Mockaco.MockacoOptions.DefaultHttpContentType.set -> void
 Mockaco.MockacoOptions.DefaultHttpStatusCode.get -> System.Net.HttpStatusCode

--- a/src/Mockaco.AspNetCore/Templating/Providers/ITemplateProvider.cs
+++ b/src/Mockaco.AspNetCore/Templating/Providers/ITemplateProvider.cs
@@ -8,5 +8,7 @@ namespace Mockaco
         event EventHandler OnChange;
 
         IEnumerable<IRawTemplate> GetTemplates();
+        void Remove(string name);
+        void Update(string name, string content);
     }
 }


### PR DESCRIPTION
Added an http api to the project to manage the template's three interfaces:

POST or GET: /{Endpoint}/list

POST: /{Endpoint}/remove

POST: /{Endpoint}/update



The Endpoint can be configured in MockacoOptions, and a simple authentication is added for the api interface, which requires a security key to be provided through the token query parameter.



This is a sloppy pr, but hopefully it will help.

Associated issue: https://github.com/natenho/Mockaco/issues/66 https://github.com/natenho/Mockaco/issues/102