### PR TITLE
Include headers in verification endpoint

### DIFF
--- a/src/Mockaco.AspNetCore/Middlewares/RequestMatchingMiddleware.cs
+++ b/src/Mockaco.AspNetCore/Middlewares/RequestMatchingMiddleware.cs
@@ -48,7 +48,7 @@ namespace Mockaco
                     {
                         Route = httpContext.Request.Path.Value,
                         Timestamp = $"{DateTime.Now.ToString("t")}",
-                        Headers = LoadHeaders(httpContext, options.Value.HiddenHeaders),
+                        Headers = LoadHeaders(httpContext, options.Value.VerificationIgnoredHeaders),
                         Body = await httpContext.Request.ReadBodyStream()
                     }, DateTime.Now.AddMinutes(options.Value.MatchedRoutesCacheDuration));
 
@@ -111,10 +111,10 @@ namespace Mockaco
             }
         }
 
-        private static IEnumerable<object> LoadHeaders(HttpContext httpContext, IEnumerable<string> hiddenHeaders)
+        private static IEnumerable<object> LoadHeaders(HttpContext httpContext, IEnumerable<string> verificationIgnoredHeaders)
         {            
             return from header in httpContext.Request.Headers.ToList()
-                   where !hiddenHeaders.Any(opt => opt == header.Key)
+                   where !verificationIgnoredHeaders.Any(opt => opt == header.Key)
                    select new { header.Key, Value = header.Value[0] };
         }
     }

--- a/src/Mockaco.AspNetCore/Middlewares/RequestMatchingMiddleware.cs
+++ b/src/Mockaco.AspNetCore/Middlewares/RequestMatchingMiddleware.cs
@@ -48,6 +48,7 @@ namespace Mockaco
                     {
                         Route = httpContext.Request.Path.Value,
                         Timestamp = $"{DateTime.Now.ToString("t")}",
+                        Headers = LoadHeaders(httpContext, options.Value.HiddenHeaders),
                         Body = await httpContext.Request.ReadBodyStream()
                     }, DateTime.Now.AddMinutes(options.Value.MatchedRoutesCacheDuration));
 
@@ -108,6 +109,13 @@ namespace Mockaco
             {
                 _logger.LogDebug("Body: {body}", body);
             }
+        }
+
+        private static IEnumerable<object> LoadHeaders(HttpContext httpContext, IEnumerable<string> hiddenHeaders)
+        {            
+            return from header in httpContext.Request.Headers.ToList()
+                   where !hiddenHeaders.Any(opt => opt == header.Key)
+                   select new { header.Key, Value = header.Value[0] };
         }
     }
 }

--- a/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
+++ b/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
@@ -12,7 +12,7 @@ namespace Mockaco
 
         public List<string> References { get; set; }
 
-        public List<string> HiddenHeaders { get; set; }
+        public List<string> VerificationIgnoredHeaders { get; set; }
         
         public List<string> Imports { get; set; }
 

--- a/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
+++ b/src/Mockaco.AspNetCore/Options/MockacoOptions.cs
@@ -12,6 +12,8 @@ namespace Mockaco
 
         public List<string> References { get; set; }
 
+        public List<string> HiddenHeaders { get; set; }
+        
         public List<string> Imports { get; set; }
 
         public int MatchedRoutesCacheDuration { get; set; }

--- a/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
@@ -48,6 +48,8 @@ Mockaco.MockacoOptions.DefaultHttpStatusCode.get -> System.Net.HttpStatusCode
 Mockaco.MockacoOptions.DefaultHttpStatusCode.set -> void
 Mockaco.MockacoOptions.ErrorHttpStatusCode.get -> System.Net.HttpStatusCode
 Mockaco.MockacoOptions.ErrorHttpStatusCode.set -> void
+Mockaco.MockacoOptions.HiddenHeaders.get -> System.Collections.Generic.List<string>
+Mockaco.MockacoOptions.HiddenHeaders.set -> void
 Mockaco.MockacoOptions.Imports.get -> System.Collections.Generic.List<string>
 Mockaco.MockacoOptions.Imports.set -> void
 Mockaco.MockacoOptions.MatchedRoutesCacheDuration.get -> int

--- a/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Mockaco.AspNetCore/PublicAPI.Unshipped.txt
@@ -48,8 +48,8 @@ Mockaco.MockacoOptions.DefaultHttpStatusCode.get -> System.Net.HttpStatusCode
 Mockaco.MockacoOptions.DefaultHttpStatusCode.set -> void
 Mockaco.MockacoOptions.ErrorHttpStatusCode.get -> System.Net.HttpStatusCode
 Mockaco.MockacoOptions.ErrorHttpStatusCode.set -> void
-Mockaco.MockacoOptions.HiddenHeaders.get -> System.Collections.Generic.List<string>
-Mockaco.MockacoOptions.HiddenHeaders.set -> void
+Mockaco.MockacoOptions.VerificationIgnoredHeaders.get -> System.Collections.Generic.List<string>
+Mockaco.MockacoOptions.VerificationIgnoredHeaders.set -> void
 Mockaco.MockacoOptions.Imports.get -> System.Collections.Generic.List<string>
 Mockaco.MockacoOptions.Imports.set -> void
 Mockaco.MockacoOptions.MatchedRoutesCacheDuration.get -> int

--- a/src/Mockaco/Settings/appsettings.json
+++ b/src/Mockaco/Settings/appsettings.json
@@ -4,6 +4,16 @@
     "ErrorHttpStatusCode": "NotImplemented",
     "DefaultHttpContentType": "application/json",
     "References": [],
+    "HiddenHeaders": [
+        "Accept",
+        "Connection",
+        "Host",
+        "User-Agent",
+        "Accept-Encoding",
+        "Postman-Token",
+        "Content-Type",
+        "Content-Length"
+    ],
     "Imports": [],
     "MatchedRoutesCacheDuration": 60,
     "MockacoEndpoint": "_mockaco",

--- a/src/Mockaco/Settings/appsettings.json
+++ b/src/Mockaco/Settings/appsettings.json
@@ -4,7 +4,7 @@
     "ErrorHttpStatusCode": "NotImplemented",
     "DefaultHttpContentType": "application/json",
     "References": [],
-    "HiddenHeaders": [
+    "VerificationIgnoredHeaders": [
         "Accept",
         "Connection",
         "Host",

--- a/website/docs/verification/index.md
+++ b/website/docs/verification/index.md
@@ -36,6 +36,50 @@ the verification endpoint called in the following way: ```http://localhost:5000/
 
 Both JSON body and x-www-form-urlencoded body are supported.
 
+### Verify request with headers
+If you have just called ```http://localhost:5000/hello/Jane Doe```, with the following headers:
+```
+    x-user-id:someone@email.com
+    Authorization:some-bearer-token
+    endtoend:b9802abd-106f-4d50-b68e-de3198777456
+```
+the verification endpoint called in the following way: ```http://localhost:5000/_mockaco/verification?route=/hello/Jane Doe``` will respond like so: 
+```
+{
+    "route": "/hello/Jane Doe",
+    "timestamp": "14:41",
+    "headers": [
+        {
+            "key": "x-user-id",
+            "value": "someone@email.com"
+        },
+        {
+            "key": "Authorization",
+            "value": "some-bearer-token"
+        },
+        {
+            "key": "endtoend",
+            "value": "b9802abd-106f-4d50-b68e-de3198777456"
+        }
+    ],
+    "body": ""
+}
+```
+
+### Configure hidden headers in verification endpoint
+You can configure to not display headers that are not relevant to your test. By default the following headers will not be displayed:  ```Accept, Connection, Host, User-Agent, Accept-Encoding, Postman-Token, Content-Type, Content-Length.```
+
+```
+"Mockaco": {
+    ...
+    "HiddenHeaders": [        
+        "Postman-Token",
+        "Some-Irrelevant-Header",
+    ],
+    ...
+  },
+```
+
 
 ## Configure custom name of verification endpoint
 

--- a/website/docs/verification/index.md
+++ b/website/docs/verification/index.md
@@ -72,7 +72,7 @@ You can configure to not display headers that are not relevant to your test. By 
 ```
 "Mockaco": {
     ...
-    "HiddenHeaders": [        
+    "VerificationIgnoredHeaders": [        
         "Postman-Token",
         "Some-Irrelevant-Header",
     ],


### PR DESCRIPTION
Hi there!
As we talked about in Issue #117 , the implementation of including headers in the verification endpoint follows.

Let me know if any change is necessary.